### PR TITLE
fix: simplify Docker tags in GitHub workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -43,9 +43,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=raw,value={{sha}}
             type=raw,value=latest,enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.title=TC4 Customer Service


### PR DESCRIPTION
- Replaced multiple tag formats with a single `raw` type approach for consistency
- Enabled `latest` tag only on default branch runs