### PR TITLE
Add ECR repository creation to build-deploy workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -34,6 +34,15 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      - name: Create ECR repository if it doesn't exist
+        run: |
+          aws ecr describe-repositories --repository-names ${{ env.ECR_REPOSITORY }} --region ${{ secrets.AWS_REGION }} || \
+          aws ecr create-repository \
+            --repository-name ${{ env.ECR_REPOSITORY }} \
+            --image-scanning-configuration scanOnPush=true \
+            --image-tag-mutability MUTABLE \
+            --region ${{ secrets.AWS_REGION }}
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2


### PR DESCRIPTION
### Summary of Changes
- Implemented a step in the build-deploy workflow to create an ECR repository if it does not already exist.
- Configured `scanOnPush` to enhance security by enabling image scan-on-push for repositories.
- Enabled mutable image tagging for flexibility in managing container images.

### Checklist
- [ ] Unit tests added/updated
- [ ] Documentation updated