### PR TITLE
Update customer creation with MongoDB ObjectID support

### DIFF
--- a/internal/core/dto/customer_dto.go
+++ b/internal/core/dto/customer_dto.go
@@ -1,19 +1,9 @@
 package dto
 
-import "github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/domain/entity"
-
 type CreateCustomerInput struct {
 	Name  string
 	Email string
 	CPF   string
-}
-
-func (i CreateCustomerInput) ToEntity() *entity.Customer {
-	return &entity.Customer{
-		Name:  i.Name,
-		Email: i.Email,
-		CPF:   i.CPF,
-	}
 }
 
 type UpdateCustomerInput struct {

--- a/internal/core/usecase/customer_usecase.go
+++ b/internal/core/usecase/customer_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"time"
 
 	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/domain"
 	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/domain/entity"
@@ -29,7 +30,14 @@ func (uc *customerUseCase) List(ctx context.Context, i dto.ListCustomersInput) (
 
 // Create creates a new Customer
 func (uc *customerUseCase) Create(ctx context.Context, i dto.CreateCustomerInput) (*entity.Customer, error) {
-	customer := i.ToEntity()
+	now := time.Now()
+	customer := &entity.Customer{
+		Name:      i.Name,
+		Email:     i.Email,
+		CPF:       i.CPF,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
 
 	if err := uc.gateway.Create(ctx, customer); err != nil {
 		return nil, domain.NewInternalError(err)

--- a/internal/infrastructure/datasource/customer_datasource.go
+++ b/internal/infrastructure/datasource/customer_datasource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/infrastructure/datasource/model"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -121,7 +122,14 @@ func (ds *customerDataSource) Create(ctx context.Context, customer *entity.Custo
 	startTime := time.Now()
 
 	customerModel := model.FromEntity(customer)
-	_, err := ds.collection.InsertOne(ctx, customerModel)
+	result, err := ds.collection.InsertOne(ctx, customerModel)
+
+	if err == nil {
+		// Update the entity with the generated MongoDB ObjectID
+		if oid, ok := result.InsertedID.(primitive.ObjectID); ok {
+			customer.ID = oid.Hex()
+		}
+	}
 
 	duration := time.Since(startTime)
 	ds.db.LogOperation(ctx, "Create", customersCollection, duration, err)


### PR DESCRIPTION
- Implemented automatic assignment of MongoDB ObjectID to customer entities upon their creation.  
- Replaced the `ToEntity` conversion method in `CreateCustomerInput` with a manual mapping approach for better flexibility.  
- Added timestamp fields `CreatedAt` and `UpdatedAt` during the creation process to ensure accurate record-keeping.