### PR TITLE
Add integration and unit tests for Customer module

### DIFF
--- a/internal/adapter/controller/customer_controller_test.go
+++ b/internal/adapter/controller/customer_controller_test.go
@@ -1,0 +1,552 @@
+package controller_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/adapter/controller"
+	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/domain/entity"
+	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/dto"
+	mockport "github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/port/mocks"
+)
+
+func TestCustomerController_List(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockUseCase := mockport.NewMockCustomerUseCase(ctrl)
+	mockPresenter := mockport.NewMockPresenter(ctrl)
+	customerController := controller.NewCustomerController(mockUseCase)
+
+	ctx := context.Background()
+	input := dto.ListCustomersInput{
+		Page:  1,
+		Limit: 10,
+	}
+
+	mockCustomers := []*entity.Customer{
+		{ID: "1", Name: "Customer 1", Email: "customer1@test.com", CPF: "123.456.789-01"},
+		{ID: "2", Name: "Customer 2", Email: "customer2@test.com", CPF: "123.456.789-02"},
+	}
+
+	tests := []struct {
+		name        string
+		setupMocks  func()
+		checkResult func(*testing.T, []byte, error)
+	}{
+		{
+			name: "should list customers successfully",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					List(ctx, input).
+					Return(mockCustomers, int64(2), nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Total:  int64(2),
+						Page:   1,
+						Limit:  10,
+						Result: mockCustomers,
+					}).
+					Return([]byte(`{"customers":[{"id":"1","name":"Customer 1"}]}`), nil)
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Contains(t, string(result), "customers")
+			},
+		},
+		{
+			name: "should return error when use case fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					List(ctx, input).
+					Return(nil, int64(0), errors.New("use case error"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "use case error", err.Error())
+			},
+		},
+		{
+			name: "should return error when presenter fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					List(ctx, input).
+					Return(mockCustomers, int64(2), nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Total:  int64(2),
+						Page:   1,
+						Limit:  10,
+						Result: mockCustomers,
+					}).
+					Return(nil, errors.New("presenter error"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "presenter error", err.Error())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMocks()
+
+			result, err := customerController.List(ctx, mockPresenter, input)
+
+			tt.checkResult(t, result, err)
+		})
+	}
+}
+
+func TestCustomerController_Create(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockUseCase := mockport.NewMockCustomerUseCase(ctrl)
+	mockPresenter := mockport.NewMockPresenter(ctrl)
+	customerController := controller.NewCustomerController(mockUseCase)
+
+	ctx := context.Background()
+	input := dto.CreateCustomerInput{
+		Name:  "New Customer",
+		Email: "new@test.com",
+		CPF:   "123.456.789-00",
+	}
+
+	mockCustomer := &entity.Customer{
+		ID:    "1",
+		Name:  "New Customer",
+		Email: "new@test.com",
+		CPF:   "123.456.789-00",
+	}
+
+	tests := []struct {
+		name        string
+		setupMocks  func()
+		checkResult func(*testing.T, []byte, error)
+	}{
+		{
+			name: "should create customer successfully",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Create(ctx, input).
+					Return(mockCustomer, nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Result: mockCustomer,
+					}).
+					Return([]byte(`{"id":"1","name":"New Customer"}`), nil)
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Contains(t, string(result), "New Customer")
+			},
+		},
+		{
+			name: "should return error when use case fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Create(ctx, input).
+					Return(nil, errors.New("use case error"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "use case error", err.Error())
+			},
+		},
+		{
+			name: "should return error when presenter fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Create(ctx, input).
+					Return(mockCustomer, nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Result: mockCustomer,
+					}).
+					Return(nil, errors.New("presenter error"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "presenter error", err.Error())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMocks()
+
+			result, err := customerController.Create(ctx, mockPresenter, input)
+
+			tt.checkResult(t, result, err)
+		})
+	}
+}
+
+func TestCustomerController_Get(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockUseCase := mockport.NewMockCustomerUseCase(ctrl)
+	mockPresenter := mockport.NewMockPresenter(ctrl)
+	customerController := controller.NewCustomerController(mockUseCase)
+
+	ctx := context.Background()
+	input := dto.GetCustomerInput{ID: "123"}
+
+	mockCustomer := &entity.Customer{
+		ID:    "123",
+		Name:  "Test Customer",
+		Email: "test@test.com",
+		CPF:   "123.456.789-01",
+	}
+
+	tests := []struct {
+		name        string
+		setupMocks  func()
+		checkResult func(*testing.T, []byte, error)
+	}{
+		{
+			name: "should get customer successfully",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Get(ctx, input).
+					Return(mockCustomer, nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Result: mockCustomer,
+					}).
+					Return([]byte(`{"id":"123","name":"Test Customer"}`), nil)
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Contains(t, string(result), "Test Customer")
+			},
+		},
+		{
+			name: "should return error when use case fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Get(ctx, input).
+					Return(nil, errors.New("customer not found"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "customer not found", err.Error())
+			},
+		},
+		{
+			name: "should return error when presenter fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Get(ctx, input).
+					Return(mockCustomer, nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Result: mockCustomer,
+					}).
+					Return(nil, errors.New("presenter error"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "presenter error", err.Error())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMocks()
+
+			result, err := customerController.Get(ctx, mockPresenter, input)
+
+			tt.checkResult(t, result, err)
+		})
+	}
+}
+
+func TestCustomerController_GetByCPF(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockUseCase := mockport.NewMockCustomerUseCase(ctrl)
+	mockPresenter := mockport.NewMockPresenter(ctrl)
+	customerController := controller.NewCustomerController(mockUseCase)
+
+	ctx := context.Background()
+	input := dto.GetCustomerByCPFInput{CPF: "123.456.789-01"}
+
+	mockCustomer := &entity.Customer{
+		ID:    "123",
+		Name:  "Test Customer",
+		Email: "test@test.com",
+		CPF:   "123.456.789-01",
+	}
+
+	tests := []struct {
+		name        string
+		setupMocks  func()
+		checkResult func(*testing.T, []byte, error)
+	}{
+		{
+			name: "should get customer by CPF successfully",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					GetByCPF(ctx, input).
+					Return(mockCustomer, nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Result: mockCustomer,
+					}).
+					Return([]byte(`{"id":"123","cpf":"123.456.789-01"}`), nil)
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Contains(t, string(result), "123.456.789-01")
+			},
+		},
+		{
+			name: "should return error when use case fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					GetByCPF(ctx, input).
+					Return(nil, errors.New("customer not found"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "customer not found", err.Error())
+			},
+		},
+		{
+			name: "should return error when presenter fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					GetByCPF(ctx, input).
+					Return(mockCustomer, nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Result: mockCustomer,
+					}).
+					Return(nil, errors.New("presenter error"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "presenter error", err.Error())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMocks()
+
+			result, err := customerController.GetByCPF(ctx, mockPresenter, input)
+
+			tt.checkResult(t, result, err)
+		})
+	}
+}
+
+func TestCustomerController_Update(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockUseCase := mockport.NewMockCustomerUseCase(ctrl)
+	mockPresenter := mockport.NewMockPresenter(ctrl)
+	customerController := controller.NewCustomerController(mockUseCase)
+
+	ctx := context.Background()
+	input := dto.UpdateCustomerInput{
+		ID:    "123",
+		Name:  "Updated Customer",
+		Email: "updated@test.com",
+	}
+
+	mockCustomer := &entity.Customer{
+		ID:    "123",
+		Name:  "Updated Customer",
+		Email: "updated@test.com",
+		CPF:   "123.456.789-01",
+	}
+
+	tests := []struct {
+		name        string
+		setupMocks  func()
+		checkResult func(*testing.T, []byte, error)
+	}{
+		{
+			name: "should update customer successfully",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Update(ctx, input).
+					Return(mockCustomer, nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Result: mockCustomer,
+					}).
+					Return([]byte(`{"id":"123","name":"Updated Customer"}`), nil)
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Contains(t, string(result), "Updated Customer")
+			},
+		},
+		{
+			name: "should return error when use case fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Update(ctx, input).
+					Return(nil, errors.New("customer not found"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "customer not found", err.Error())
+			},
+		},
+		{
+			name: "should return error when presenter fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Update(ctx, input).
+					Return(mockCustomer, nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Result: mockCustomer,
+					}).
+					Return(nil, errors.New("presenter error"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "presenter error", err.Error())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMocks()
+
+			result, err := customerController.Update(ctx, mockPresenter, input)
+
+			tt.checkResult(t, result, err)
+		})
+	}
+}
+
+func TestCustomerController_Delete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockUseCase := mockport.NewMockCustomerUseCase(ctrl)
+	mockPresenter := mockport.NewMockPresenter(ctrl)
+	customerController := controller.NewCustomerController(mockUseCase)
+
+	ctx := context.Background()
+	input := dto.DeleteCustomerInput{ID: "123"}
+
+	mockCustomer := &entity.Customer{
+		ID:    "123",
+		Name:  "Deleted Customer",
+		Email: "deleted@test.com",
+		CPF:   "123.456.789-01",
+	}
+
+	tests := []struct {
+		name        string
+		setupMocks  func()
+		checkResult func(*testing.T, []byte, error)
+	}{
+		{
+			name: "should delete customer successfully",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Delete(ctx, input).
+					Return(mockCustomer, nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Result: mockCustomer,
+					}).
+					Return([]byte(`{"id":"123","name":"Deleted Customer"}`), nil)
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Contains(t, string(result), "Deleted Customer")
+			},
+		},
+		{
+			name: "should return error when use case fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Delete(ctx, input).
+					Return(nil, errors.New("customer not found"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "customer not found", err.Error())
+			},
+		},
+		{
+			name: "should return error when presenter fails",
+			setupMocks: func() {
+				mockUseCase.EXPECT().
+					Delete(ctx, input).
+					Return(mockCustomer, nil)
+
+				mockPresenter.EXPECT().
+					Present(dto.PresenterInput{
+						Result: mockCustomer,
+					}).
+					Return(nil, errors.New("presenter error"))
+			},
+			checkResult: func(t *testing.T, result []byte, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				assert.Equal(t, "presenter error", err.Error())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMocks()
+
+			result, err := customerController.Delete(ctx, mockPresenter, input)
+
+			tt.checkResult(t, result, err)
+		})
+	}
+}

--- a/internal/infrastructure/datasource/customer_datasource_integration_suite_test.go
+++ b/internal/infrastructure/datasource/customer_datasource_integration_suite_test.go
@@ -69,6 +69,9 @@ func TestCustomerDataSourceIntegrationTestSuite(t *testing.T) {
 }
 
 func getTestMongoURI() string {
+	if uri := os.Getenv("MONGO_URI"); uri != "" {
+		return uri
+	}
 	if uri := os.Getenv("TEST_MONGODB_URI"); uri != "" {
 		return uri
 	}

--- a/internal/infrastructure/datasource/customer_datasource_integration_suite_test.go
+++ b/internal/infrastructure/datasource/customer_datasource_integration_suite_test.go
@@ -1,0 +1,76 @@
+package datasource_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/port"
+	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/infrastructure/config"
+	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/infrastructure/database"
+	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/infrastructure/datasource"
+	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/infrastructure/logger"
+)
+
+type CustomerDataSourceIntegrationTestSuite struct {
+	suite.Suite
+	ctx        context.Context
+	db         *database.MongoDatabase
+	dataSource port.CustomerDataSource
+	collection *mongo.Collection
+}
+
+func (suite *CustomerDataSourceIntegrationTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+
+	cfg := &config.Config{
+		MongoURI:         getTestMongoURI(),
+		MongoDatabase:    "customer_service_integration_test",
+		MongoTimeout:     30 * time.Second,
+		MongoMaxPoolSize: 10,
+		MongoMinPoolSize: 1,
+	}
+
+	l := logger.NewLogger(cfg)
+
+	var err error
+	suite.db, err = database.NewMongoConnection(cfg, l)
+	require.NoError(suite.T(), err, "Failed to connect to test MongoDB")
+
+	suite.dataSource = datasource.NewCustomerDataSource(suite.db).(port.CustomerDataSource)
+	suite.collection = suite.db.Collection("customers")
+}
+
+func (suite *CustomerDataSourceIntegrationTestSuite) TearDownSuite() {
+	if suite.db != nil {
+		suite.db.Close(suite.ctx)
+	}
+}
+
+func (suite *CustomerDataSourceIntegrationTestSuite) SetupTest() {
+	suite.collection.Drop(suite.ctx)
+}
+
+func (suite *CustomerDataSourceIntegrationTestSuite) TearDownTest() {
+	suite.collection.Drop(suite.ctx)
+}
+
+func TestCustomerDataSourceIntegrationTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	suite.Run(t, new(CustomerDataSourceIntegrationTestSuite))
+}
+
+func getTestMongoURI() string {
+	if uri := os.Getenv("TEST_MONGODB_URI"); uri != "" {
+		return uri
+	}
+	return "mongodb://admin:admin@localhost:27017"
+}

--- a/internal/infrastructure/datasource/customer_datasource_integration_test.go
+++ b/internal/infrastructure/datasource/customer_datasource_integration_test.go
@@ -1,0 +1,386 @@
+package datasource_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/domain/entity"
+)
+
+func (suite *CustomerDataSourceIntegrationTestSuite) TestCreate() {
+	tests := []struct {
+		name     string
+		customer *entity.Customer
+		wantErr  bool
+	}{
+		{
+			name: "should create customer successfully",
+			customer: &entity.Customer{
+				Name:      "John Doe",
+				Email:     "john.doe@example.com",
+				CPF:       "123.456.789-01",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "should create customer with special characters",
+			customer: &entity.Customer{
+				Name:      "José da Silva",
+				Email:     "jose.silva@example.com",
+				CPF:       "987.654.321-09",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			// Clear collection before each test
+			suite.collection.Drop(suite.ctx)
+
+			err := suite.dataSource.Create(suite.ctx, tt.customer)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotEmpty(t, tt.customer.ID, "Customer ID should be set after creation")
+
+				count, err := suite.collection.CountDocuments(suite.ctx, bson.M{})
+				assert.NoError(t, err)
+				assert.Equal(t, int64(1), count, "Should have exactly one customer in collection")
+			}
+		})
+	}
+}
+
+func (suite *CustomerDataSourceIntegrationTestSuite) TestFindByID() {
+	customer := &entity.Customer{
+		Name:      "Jane Doe",
+		Email:     "jane.doe@example.com",
+		CPF:       "111.222.333-44",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	err := suite.dataSource.Create(suite.ctx, customer)
+	require.NoError(suite.T(), err)
+
+	tests := []struct {
+		name      string
+		id        string
+		wantFound bool
+	}{
+		{
+			name:      "should find existing customer",
+			id:        customer.ID,
+			wantFound: true,
+		},
+		{
+			name:      "should return nil for non-existent customer",
+			id:        "507f1f77bcf86cd799439011",
+			wantFound: false,
+		},
+		{
+			name:      "should return error for invalid ObjectID",
+			id:        "invalid-id",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			result, err := suite.dataSource.FindByID(suite.ctx, tt.id)
+
+			if tt.id == "invalid-id" {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else if tt.wantFound {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, customer.Name, result.Name)
+				assert.Equal(t, customer.Email, result.Email)
+				assert.Equal(t, customer.CPF, result.CPF)
+			} else {
+				assert.NoError(t, err)
+				assert.Nil(t, result)
+			}
+		})
+	}
+}
+
+func (suite *CustomerDataSourceIntegrationTestSuite) TestFindByCPF() {
+	customer := &entity.Customer{
+		Name:      "Bob Smith",
+		Email:     "bob.smith@example.com",
+		CPF:       "555.666.777-88",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	err := suite.dataSource.Create(suite.ctx, customer)
+	require.NoError(suite.T(), err)
+
+	tests := []struct {
+		name      string
+		cpf       string
+		wantFound bool
+	}{
+		{
+			name:      "should find existing customer by CPF",
+			cpf:       "555.666.777-88",
+			wantFound: true,
+		},
+		{
+			name:      "should return nil for non-existent CPF",
+			cpf:       "999.888.777-66",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			result, err := suite.dataSource.FindByCPF(suite.ctx, tt.cpf)
+
+			if tt.wantFound {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, customer.Name, result.Name)
+				assert.Equal(t, customer.Email, result.Email)
+				assert.Equal(t, tt.cpf, result.CPF)
+			} else {
+				assert.NoError(t, err)
+				assert.Nil(t, result)
+			}
+		})
+	}
+}
+
+func (suite *CustomerDataSourceIntegrationTestSuite) TestFindAll() {
+	customers := []*entity.Customer{
+		{
+			Name:      "Alice Johnson",
+			Email:     "alice.johnson@example.com",
+			CPF:       "111.111.111-11",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		{
+			Name:      "Alice Smith",
+			Email:     "alice.smith@example.com",
+			CPF:       "222.222.222-22",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		{
+			Name:      "Bob Johnson",
+			Email:     "bob.johnson@example.com",
+			CPF:       "333.333.333-33",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	}
+
+	for _, customer := range customers {
+		err := suite.dataSource.Create(suite.ctx, customer)
+		require.NoError(suite.T(), err)
+	}
+
+	tests := []struct {
+		name        string
+		filters     map[string]interface{}
+		page        int
+		limit       int
+		wantCount   int
+		wantTotal   int64
+		checkResult func(*testing.T, []*entity.Customer)
+	}{
+		{
+			name:      "should find all customers without filters",
+			filters:   map[string]interface{}{},
+			page:      1,
+			limit:     10,
+			wantCount: 3,
+			wantTotal: 3,
+			checkResult: func(t *testing.T, result []*entity.Customer) {
+				assert.Len(t, result, 3)
+			},
+		},
+		{
+			name:      "should filter customers by name pattern",
+			filters:   map[string]interface{}{"name": bson.M{"$regex": "Alice", "$options": "i"}},
+			page:      1,
+			limit:     10,
+			wantCount: 2,
+			wantTotal: 2,
+			checkResult: func(t *testing.T, result []*entity.Customer) {
+				assert.Len(t, result, 2)
+				for _, customer := range result {
+					assert.Contains(t, customer.Name, "Alice")
+				}
+			},
+		},
+		{
+			name:      "should paginate results",
+			filters:   map[string]interface{}{},
+			page:      2,
+			limit:     2,
+			wantCount: 1,
+			wantTotal: 3,
+			checkResult: func(t *testing.T, result []*entity.Customer) {
+				assert.Len(t, result, 1)
+			},
+		},
+		{
+			name:      "should return empty result for non-matching filter",
+			filters:   map[string]interface{}{"name": "Non-existent"},
+			page:      1,
+			limit:     10,
+			wantCount: 0,
+			wantTotal: 0,
+			checkResult: func(t *testing.T, result []*entity.Customer) {
+				assert.Empty(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			result, total, err := suite.dataSource.FindAll(suite.ctx, tt.filters, tt.page, tt.limit)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantTotal, total)
+			assert.Len(t, result, tt.wantCount)
+
+			if tt.checkResult != nil {
+				tt.checkResult(t, result)
+			}
+		})
+	}
+}
+
+func (suite *CustomerDataSourceIntegrationTestSuite) TestUpdate() {
+	customer := &entity.Customer{
+		Name:      "Original Name",
+		Email:     "original@example.com",
+		CPF:       "123.456.789-00",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	err := suite.dataSource.Create(suite.ctx, customer)
+	require.NoError(suite.T(), err)
+
+	tests := []struct {
+		name        string
+		updateData  func(*entity.Customer)
+		wantErr     bool
+		checkResult func(*testing.T, *entity.Customer)
+	}{
+		{
+			name: "should update customer successfully",
+			updateData: func(c *entity.Customer) {
+				c.Name = "Updated Name"
+				c.Email = "updated@example.com"
+				c.UpdatedAt = time.Now()
+			},
+			wantErr: false,
+			checkResult: func(t *testing.T, updated *entity.Customer) {
+				assert.Equal(t, "Updated Name", updated.Name)
+				assert.Equal(t, "updated@example.com", updated.Email)
+				assert.Equal(t, "123.456.789-00", updated.CPF)
+			},
+		},
+		{
+			name: "should fail to update with invalid ID",
+			updateData: func(c *entity.Customer) {
+				c.ID = "invalid-id"
+				c.Name = "Should not update"
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			testCustomer := *customer
+			tt.updateData(&testCustomer)
+
+			err := suite.dataSource.Update(suite.ctx, &testCustomer)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				if tt.checkResult != nil {
+					updated, err := suite.dataSource.FindByID(suite.ctx, customer.ID)
+					assert.NoError(t, err)
+					assert.NotNil(t, updated)
+					tt.checkResult(t, updated)
+				}
+			}
+		})
+	}
+}
+
+func (suite *CustomerDataSourceIntegrationTestSuite) TestDelete() {
+	customer := &entity.Customer{
+		Name:      "To Delete",
+		Email:     "delete@example.com",
+		CPF:       "999.999.999-99",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	err := suite.dataSource.Create(suite.ctx, customer)
+	require.NoError(suite.T(), err)
+
+	tests := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{
+			name:    "should delete existing customer",
+			id:      customer.ID,
+			wantErr: false,
+		},
+		{
+			name:    "should not error when deleting non-existent customer",
+			id:      "507f1f77bcf86cd799439011",
+			wantErr: false,
+		},
+		{
+			name:    "should error with invalid ObjectID",
+			id:      "invalid-id",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			err := suite.dataSource.Delete(suite.ctx, tt.id)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				if tt.id == customer.ID {
+					found, err := suite.dataSource.FindByID(suite.ctx, customer.ID)
+					assert.NoError(t, err)
+					assert.Nil(t, found, "Customer should not exist after deletion")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

This pull request introduces the following updates:

- **Datasource Integration Tests**:  
  Adds a comprehensive integration test suite for `CustomerDataSource`, ensuring coverage for CRUD operations including `Create`, `FindByID`, `FindByCPF`, `FindAll`, `Update`, and `Delete`. It ensures data isolation and integrity during test runs.

- **Environment Variable Update**:  
  Updates the test setup to use the `MONGO_URI` environment variable as a fallback for `TEST_MONGODB_URI`.

- **Controller Unit Tests**:  
  Implements unit tests for the `CustomerController` to validate methods such as `List`, `Create`, `Get`, `GetByCPF`, `Update`, and `Delete`. Includes both success and error scenarios to ensure robust validation of logic and interaction with use cases.

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works. 
- [ ] I have added necessary documentation (if applicable). 
- [ ] Any dependent changes have been merged and published in downstream modules. 

### Additional Notes

Testing ensures the functional integrity of both the `CustomerDataSource` and `CustomerController` for consistent behavior and reliability in operations.