### PR TITLE
Remove redundant condition in CI workflow

### DIFF
--- a/.github/workflows/ci-build-deploy.yml
+++ b/.github/workflows/ci-build-deploy.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
     permissions:
       contents: read


### PR DESCRIPTION
## Description

This pull request removes a redundant condition in the `ci-build-deploy.yml` workflow file for better clarity and maintainability.

## Changes

- Removed `github.event.workflow_run.event` check from the CI workflow.

## Additional Information

These changes simplify the logic and improve the maintainability of CI workflow triggers.

## Checklist

- [ ] Tests passed
- [ ] Changes are covered by tests
- [ ] Documentation updated
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)