### PR TITLE
Convert customer ID type from string to integer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,13 @@ trigger-lambda: ## ⚡  Trigger lambda with the input file stored in variable $L
 	@echo
 
 mock: ## Generate mocks
-	@echo  "🟢 Generating mocks..."
+	@echo "🟢 Generating mocks..."
 	@go install go.uber.org/mock/mockgen@latest
 	@mkdir -p internal/core/port/mocks
-	@rm -rf internal/core/port/mocks/*
-	@for file in internal/core/port/*.go; do \
-		mockgen -source=$$file -destination=internal/core/port/mocks/`basename $$file _port.go`_mock.go -package=mocks; \
-	done
+	@rm -f internal/core/port/mocks/*.go
+	@mockgen -source=internal/core/port/customer_port.go -destination=internal/core/port/mocks/customer_mock.go -package=mocks
+	@mockgen -source=internal/core/port/authentication_port.go -destination=internal/core/port/mocks/authentication_mock.go -package=mocks
+	@mockgen -source=internal/core/port/presenter_port.go -destination=internal/core/port/mocks/presenter_mock.go -package=mocks
 
 
 .PHONY: test

--- a/internal/adapter/controller/customer_controller_test.go
+++ b/internal/adapter/controller/customer_controller_test.go
@@ -29,8 +29,8 @@ func TestCustomerController_List(t *testing.T) {
 	}
 
 	mockCustomers := []*entity.Customer{
-		{ID: "1", Name: "Customer 1", Email: "customer1@test.com", CPF: "123.456.789-01"},
-		{ID: "2", Name: "Customer 2", Email: "customer2@test.com", CPF: "123.456.789-02"},
+		{ID: 1, Name: "Customer 1", Email: "customer1@test.com", CPF: "123.456.789-01"},
+		{ID: 2, Name: "Customer 2", Email: "customer2@test.com", CPF: "123.456.789-02"},
 	}
 
 	tests := []struct {
@@ -124,7 +124,7 @@ func TestCustomerController_Create(t *testing.T) {
 	}
 
 	mockCustomer := &entity.Customer{
-		ID:    "1",
+		ID:    1,
 		Name:  "New Customer",
 		Email: "new@test.com",
 		CPF:   "123.456.789-00",
@@ -208,10 +208,10 @@ func TestCustomerController_Get(t *testing.T) {
 	customerController := controller.NewCustomerController(mockUseCase)
 
 	ctx := context.Background()
-	input := dto.GetCustomerInput{ID: "123"}
+	input := dto.GetCustomerInput{ID: 123}
 
 	mockCustomer := &entity.Customer{
-		ID:    "123",
+		ID:    123,
 		Name:  "Test Customer",
 		Email: "test@test.com",
 		CPF:   "123.456.789-01",
@@ -298,7 +298,7 @@ func TestCustomerController_GetByCPF(t *testing.T) {
 	input := dto.GetCustomerByCPFInput{CPF: "123.456.789-01"}
 
 	mockCustomer := &entity.Customer{
-		ID:    "123",
+		ID:    123,
 		Name:  "Test Customer",
 		Email: "test@test.com",
 		CPF:   "123.456.789-01",
@@ -383,13 +383,13 @@ func TestCustomerController_Update(t *testing.T) {
 
 	ctx := context.Background()
 	input := dto.UpdateCustomerInput{
-		ID:    "123",
+		ID:    123,
 		Name:  "Updated Customer",
 		Email: "updated@test.com",
 	}
 
 	mockCustomer := &entity.Customer{
-		ID:    "123",
+		ID:    123,
 		Name:  "Updated Customer",
 		Email: "updated@test.com",
 		CPF:   "123.456.789-01",
@@ -473,10 +473,10 @@ func TestCustomerController_Delete(t *testing.T) {
 	customerController := controller.NewCustomerController(mockUseCase)
 
 	ctx := context.Background()
-	input := dto.DeleteCustomerInput{ID: "123"}
+	input := dto.DeleteCustomerInput{ID: 123}
 
 	mockCustomer := &entity.Customer{
-		ID:    "123",
+		ID:    123,
 		Name:  "Deleted Customer",
 		Email: "deleted@test.com",
 		CPF:   "123.456.789-01",

--- a/internal/adapter/gateway/customer_gateway.go
+++ b/internal/adapter/gateway/customer_gateway.go
@@ -15,7 +15,7 @@ func NewCustomerGateway(dataSource port.CustomerDataSource) port.CustomerGateway
 	return &customerGateway{dataSource}
 }
 
-func (g *customerGateway) FindByID(ctx context.Context, id string) (*entity.Customer, error) {
+func (g *customerGateway) FindByID(ctx context.Context, id int) (*entity.Customer, error) {
 	return g.dataSource.FindByID(ctx, id)
 }
 
@@ -40,6 +40,6 @@ func (g *customerGateway) Update(ctx context.Context, customer *entity.Customer)
 	return g.dataSource.Update(ctx, customer)
 }
 
-func (g *customerGateway) Delete(ctx context.Context, id string) error {
+func (g *customerGateway) Delete(ctx context.Context, id int) error {
 	return g.dataSource.Delete(ctx, id)
 }

--- a/internal/adapter/presenter/customer_json_response.go
+++ b/internal/adapter/presenter/customer_json_response.go
@@ -3,7 +3,7 @@ package presenter
 import "encoding/json"
 
 type CustomerJsonResponse struct {
-	ID        string `json:"id" example:"1"`
+	ID        int    `json:"id" example:"1"`
 	Name      string `json:"name" example:"John Doe"`
 	Email     string `json:"email" example:"john.doe@email.com"`
 	CPF       string `json:"cpf" example:"123.456.789-00"`

--- a/internal/adapter/presenter/customer_jwt_token_presenter.go
+++ b/internal/adapter/presenter/customer_jwt_token_presenter.go
@@ -3,6 +3,7 @@ package presenter
 import (
 	"encoding/json"
 	"errors"
+	"strconv"
 
 	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/domain"
 	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/domain/entity"
@@ -32,7 +33,7 @@ func toCustomerJsonResponse(accessToken, tokenType string, expiresIn int64) JWTR
 func (p *customerJwtTokenPresenter) Present(pp dto.PresenterInput) ([]byte, error) {
 	switch v := pp.Result.(type) {
 	case *entity.Customer:
-		accessToken, tokenType, expiresIn, err := p.jwtService.GenerateToken(v.ID)
+		accessToken, tokenType, expiresIn, err := p.jwtService.GenerateToken(strconv.Itoa(v.ID))
 		if err != nil {
 			return nil, domain.NewInternalError(errors.New(domain.ErrInternalError))
 		}

--- a/internal/adapter/presenter/customer_jwt_token_presenter_test.go
+++ b/internal/adapter/presenter/customer_jwt_token_presenter_test.go
@@ -22,7 +22,7 @@ func TestCustomerJwtTokenPresenter_Present_Success(t *testing.T) {
 	jwtService := mock_port.NewMockIAuthenticationService(ctrl)
 	presenter := NewCustomerJwtTokenPresenter(jwtService)
 
-	customer := &entity.Customer{ID: "999"}
+	customer := &entity.Customer{ID: 999}
 	jwtService.EXPECT().
 		GenerateToken("999").
 		Return("atoken", "Bearer", int64(12345), nil)
@@ -47,7 +47,7 @@ func TestCustomerJwtTokenPresenter_Present_GenerateTokenError(t *testing.T) {
 	jwtService := mock_port.NewMockIAuthenticationService(ctrl)
 	presenter := NewCustomerJwtTokenPresenter(jwtService)
 
-	customer := &entity.Customer{ID: "2"}
+	customer := &entity.Customer{ID: 2}
 	jwtService.EXPECT().
 		GenerateToken("2").
 		Return("", "", int64(0), errors.New("fail"))

--- a/internal/core/domain/entity/customer_entity.go
+++ b/internal/core/domain/entity/customer_entity.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Customer struct {
-	ID        string
+	ID        int
 	Name      string
 	Email     string
 	CPF       string

--- a/internal/core/dto/customer_dto.go
+++ b/internal/core/dto/customer_dto.go
@@ -7,13 +7,13 @@ type CreateCustomerInput struct {
 }
 
 type UpdateCustomerInput struct {
-	ID    string
+	ID    int
 	Name  string
 	Email string
 }
 
 type GetCustomerInput struct {
-	ID string
+	ID int
 }
 
 type GetCustomerByCPFInput struct {
@@ -21,7 +21,7 @@ type GetCustomerByCPFInput struct {
 }
 
 type DeleteCustomerInput struct {
-	ID string
+	ID int
 }
 
 type ListCustomersInput struct {

--- a/internal/core/port/customer_port.go
+++ b/internal/core/port/customer_port.go
@@ -26,19 +26,19 @@ type CustomerUseCase interface {
 }
 
 type CustomerGateway interface {
-	FindByID(ctx context.Context, id string) (*entity.Customer, error)
+	FindByID(ctx context.Context, id int) (*entity.Customer, error)
 	FindByCPF(ctx context.Context, cpf string) (*entity.Customer, error)
 	FindAll(ctx context.Context, name string, page, limit int) ([]*entity.Customer, int64, error)
 	Create(ctx context.Context, customer *entity.Customer) error
 	Update(ctx context.Context, customer *entity.Customer) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id int) error
 }
 
 type CustomerDataSource interface {
-	FindByID(ctx context.Context, id string) (*entity.Customer, error)
+	FindByID(ctx context.Context, id int) (*entity.Customer, error)
 	FindByCPF(ctx context.Context, cpf string) (*entity.Customer, error)
 	FindAll(ctx context.Context, filters map[string]interface{}, page, limit int) ([]*entity.Customer, int64, error)
 	Create(ctx context.Context, product *entity.Customer) error
 	Update(ctx context.Context, product *entity.Customer) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id int) error
 }

--- a/internal/core/port/mocks/customer_mock.go
+++ b/internal/core/port/mocks/customer_mock.go
@@ -287,7 +287,7 @@ func (mr *MockCustomerGatewayMockRecorder) Create(ctx, customer any) *gomock.Cal
 }
 
 // Delete mocks base method.
-func (m *MockCustomerGateway) Delete(ctx context.Context, id string) error {
+func (m *MockCustomerGateway) Delete(ctx context.Context, id int) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", ctx, id)
 	ret0, _ := ret[0].(error)
@@ -332,7 +332,7 @@ func (mr *MockCustomerGatewayMockRecorder) FindByCPF(ctx, cpf any) *gomock.Call 
 }
 
 // FindByID mocks base method.
-func (m *MockCustomerGateway) FindByID(ctx context.Context, id string) (*entity.Customer, error) {
+func (m *MockCustomerGateway) FindByID(ctx context.Context, id int) (*entity.Customer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindByID", ctx, id)
 	ret0, _ := ret[0].(*entity.Customer)
@@ -399,7 +399,7 @@ func (mr *MockCustomerDataSourceMockRecorder) Create(ctx, product any) *gomock.C
 }
 
 // Delete mocks base method.
-func (m *MockCustomerDataSource) Delete(ctx context.Context, id string) error {
+func (m *MockCustomerDataSource) Delete(ctx context.Context, id int) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", ctx, id)
 	ret0, _ := ret[0].(error)
@@ -444,7 +444,7 @@ func (mr *MockCustomerDataSourceMockRecorder) FindByCPF(ctx, cpf any) *gomock.Ca
 }
 
 // FindByID mocks base method.
-func (m *MockCustomerDataSource) FindByID(ctx context.Context, id string) (*entity.Customer, error) {
+func (m *MockCustomerDataSource) FindByID(ctx context.Context, id int) (*entity.Customer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindByID", ctx, id)
 	ret0, _ := ret[0].(*entity.Customer)

--- a/internal/core/usecase/customer_usecase_test.go
+++ b/internal/core/usecase/customer_usecase_test.go
@@ -20,7 +20,7 @@ func createMockCustomers() []*entity.Customer {
 	currentTime := time.Now()
 	return []*entity.Customer{
 		{
-			ID:        "123",
+			ID:        123,
 			Name:      "Test Customer 1",
 			Email:     "test.customer.1@email.com",
 			CPF:       "12345678901",
@@ -28,7 +28,7 @@ func createMockCustomers() []*entity.Customer {
 			UpdatedAt: currentTime,
 		},
 		{
-			ID:        "321",
+			ID:        321,
 			Name:      "Test Customer 2",
 			Email:     "test.customer.2@email.com",
 			CPF:       "12345678902",
@@ -213,10 +213,10 @@ func TestCustomerUseCase_Get(t *testing.T) {
 	}{
 		{
 			name:  "should get customer successfully",
-			input: dto.GetCustomerInput{ID: "123"},
+			input: dto.GetCustomerInput{ID: 123},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
+					FindByID(ctx, 123).
 					Return(mockCustomers[0], nil)
 			},
 			checkResult: func(t *testing.T, customer *entity.Customer, err error) {
@@ -231,10 +231,10 @@ func TestCustomerUseCase_Get(t *testing.T) {
 		},
 		{
 			name:  "should return not found error when customer doesn't exist",
-			input: dto.GetCustomerInput{ID: "123"},
+			input: dto.GetCustomerInput{ID: 123},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
+					FindByID(ctx, 123).
 					Return(nil, nil)
 			},
 			checkResult: func(t *testing.T, customer *entity.Customer, err error) {
@@ -245,10 +245,10 @@ func TestCustomerUseCase_Get(t *testing.T) {
 		},
 		{
 			name:  "should return internal error when gateway fails",
-			input: dto.GetCustomerInput{ID: "123"},
+			input: dto.GetCustomerInput{ID: 123},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
+					FindByID(ctx, 123).
 					Return(nil, assert.AnError)
 			},
 			checkResult: func(t *testing.T, customer *entity.Customer, err error) {
@@ -292,13 +292,13 @@ func TestCustomerUseCase_Update(t *testing.T) {
 		{
 			name: "should update customer successfully",
 			input: dto.UpdateCustomerInput{
-				ID:    "123",
+				ID:    123,
 				Name:  "New Name",
 				Email: "new.name@email.com",
 			},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
+					FindByID(ctx, 123).
 					Return(mockCustomers[0], nil)
 
 				mockGateway.EXPECT().
@@ -320,13 +320,13 @@ func TestCustomerUseCase_Update(t *testing.T) {
 		{
 			name: "should return error when customer not found",
 			input: dto.UpdateCustomerInput{
-				ID:    "123",
+				ID:    123,
 				Name:  "New Name",
 				Email: "new.name@email.com",
 			},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
+					FindByID(ctx, 123).
 					Return(nil, nil)
 			},
 			checkResult: func(t *testing.T, customer *entity.Customer, err error) {
@@ -338,13 +338,13 @@ func TestCustomerUseCase_Update(t *testing.T) {
 		{
 			name: "should return error when gateway find fails",
 			input: dto.UpdateCustomerInput{
-				ID:    "123",
+				ID:    123,
 				Name:  "New Name",
 				Email: "new.name@email.com",
 			},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
+					FindByID(ctx, 123).
 					Return(nil, assert.AnError)
 			},
 			checkResult: func(t *testing.T, customer *entity.Customer, err error) {
@@ -356,13 +356,13 @@ func TestCustomerUseCase_Update(t *testing.T) {
 		{
 			name: "should return error when gateway update fails",
 			input: dto.UpdateCustomerInput{
-				ID:    "123",
+				ID:    123,
 				Name:  "New Name",
 				Email: "new.name@email.com",
 			},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
+					FindByID(ctx, 123).
 					Return(mockCustomers[0], nil)
 
 				mockGateway.EXPECT().
@@ -408,28 +408,28 @@ func TestCustomerUseCase_Delete(t *testing.T) {
 	}{
 		{
 			name:  "should delete customer successfully",
-			input: dto.DeleteCustomerInput{ID: "123"},
+			input: dto.DeleteCustomerInput{ID: 123},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
-					Return(&entity.Customer{ID: "123"}, nil)
+					FindByID(ctx, 123).
+					Return(&entity.Customer{ID: 123}, nil)
 
 				mockGateway.EXPECT().
-					Delete(ctx, "123").
+					Delete(ctx, 123).
 					Return(nil)
 			},
 			checkResult: func(t *testing.T, customer *entity.Customer, err error) {
 				assert.NoError(t, err)
 				assert.NotNil(t, customer)
-				assert.Equal(t, "123", customer.ID)
+				assert.Equal(t, 123, customer.ID)
 			},
 		},
 		{
 			name:  "should return not found error when customer doesn't exist",
-			input: dto.DeleteCustomerInput{ID: "123"},
+			input: dto.DeleteCustomerInput{ID: 123},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
+					FindByID(ctx, 123).
 					Return(nil, nil)
 			},
 			checkResult: func(t *testing.T, customer *entity.Customer, err error) {
@@ -440,10 +440,10 @@ func TestCustomerUseCase_Delete(t *testing.T) {
 		},
 		{
 			name:  "should return error when gateway fails on find",
-			input: dto.DeleteCustomerInput{ID: "123"},
+			input: dto.DeleteCustomerInput{ID: 123},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
+					FindByID(ctx, 123).
 					Return(nil, assert.AnError)
 			},
 			checkResult: func(t *testing.T, customer *entity.Customer, err error) {
@@ -454,14 +454,14 @@ func TestCustomerUseCase_Delete(t *testing.T) {
 		},
 		{
 			name:  "should return error when gateway fails on delete",
-			input: dto.DeleteCustomerInput{ID: "123"},
+			input: dto.DeleteCustomerInput{ID: 123},
 			setupMocks: func() {
 				mockGateway.EXPECT().
-					FindByID(ctx, "123").
+					FindByID(ctx, 123).
 					Return(&entity.Customer{}, nil)
 
 				mockGateway.EXPECT().
-					Delete(ctx, "123").
+					Delete(ctx, 123).
 					Return(assert.AnError)
 			},
 			checkResult: func(t *testing.T, customer *entity.Customer, err error) {

--- a/internal/infrastructure/aws/lambda/lambda.go
+++ b/internal/infrastructure/aws/lambda/lambda.go
@@ -149,7 +149,12 @@ func handleGetRequest(ctx context.Context, req events.APIGatewayProxyRequest) (e
 	}
 
 	// Get by ID
-	input := dto.GetCustomerInput{ID: customerID}
+	id, err := strconv.Atoi(customerID)
+	if err != nil {
+		l.ErrorContext(ctx, "Invalid customer ID", "id", customerID, "error", err)
+		return response.NewAPIGatewayProxyResponseError(err), nil
+	}
+	input := dto.GetCustomerInput{ID: id}
 	resp, err := customerController.Get(ctx, jsonPresenter, input)
 	if err != nil {
 		l.ErrorContext(ctx, "Failed to get customer", "id", customerID, "error", err)
@@ -211,8 +216,14 @@ func handlePutRequest(ctx context.Context, req events.APIGatewayProxyRequest) (e
 		return response.NewAPIGatewayProxyResponseError(&domain.InvalidInputError{Message: err.Error()}), nil
 	}
 
+	id, err := strconv.Atoi(customerID)
+	if err != nil {
+		l.ErrorContext(ctx, "Invalid customer ID", "id", customerID, "error", err)
+		return response.NewAPIGatewayProxyResponseError(err), nil
+	}
+
 	input := customerRequest.ToUpdateCustomerInput()
-	input.ID = customerID
+	input.ID = id
 
 	resp, err := customerController.Update(ctx, jsonPresenter, input)
 	if err != nil {
@@ -232,7 +243,13 @@ func handleDeleteRequest(ctx context.Context, req events.APIGatewayProxyRequest)
 		}), nil
 	}
 
-	input := dto.DeleteCustomerInput{ID: customerID}
+	id, err := strconv.Atoi(customerID)
+	if err != nil {
+		l.ErrorContext(ctx, "Invalid customer ID", "id", customerID, "error", err)
+		return response.NewAPIGatewayProxyResponseError(err), nil
+	}
+
+	input := dto.DeleteCustomerInput{ID: id}
 	resp, err := customerController.Delete(ctx, jsonPresenter, input)
 	if err != nil {
 		l.ErrorContext(ctx, "Failed to delete customer", "id", customerID, "error", err)

--- a/internal/infrastructure/aws/lambda/lambda_test.go
+++ b/internal/infrastructure/aws/lambda/lambda_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/domain"
 	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/dto"
 	mockport "github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/port/mocks"
 )
@@ -34,7 +33,7 @@ func TestHandleRequest_GetByID_Success(t *testing.T) {
 
 	// Prepare input and expected request/response for GET by ID
 	customerID := "123"
-	reqInput := dto.GetCustomerInput{ID: customerID}
+	reqInput := dto.GetCustomerInput{ID: 123}
 
 	lambdaReq := events.APIGatewayProxyRequest{
 		HTTPMethod: "GET",
@@ -79,7 +78,6 @@ func TestHandleRequest_ControllerError(t *testing.T) {
 	customerController = mockController
 
 	customerID := "wrong"
-	reqInput := dto.GetCustomerInput{ID: customerID}
 
 	lambdaReq := events.APIGatewayProxyRequest{
 		HTTPMethod: "GET",
@@ -88,15 +86,10 @@ func TestHandleRequest_ControllerError(t *testing.T) {
 		},
 	}
 
-	mockController.
-		EXPECT().
-		Get(gomock.Any(), gomock.Any(), reqInput).
-		Return(nil, &domain.NotFoundError{Message: "not found"}).
-		Times(1)
-
+	// Test expects an invalid ID to return 500 error (not 404) since conversion fails
 	resp, _ := handleRequest(context.Background(), lambdaReq)
-	assert.Equal(t, 404, resp.StatusCode)
-	assert.Contains(t, resp.Body, "not found")
+	assert.Equal(t, 500, resp.StatusCode)
+	assert.Contains(t, resp.Body, "invalid syntax")
 }
 
 func TestHandleRequest_CreateCustomer_Success(t *testing.T) {

--- a/internal/infrastructure/aws/lambda/request/customer_request.go
+++ b/internal/infrastructure/aws/lambda/request/customer_request.go
@@ -1,6 +1,10 @@
 package request
 
-import "github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/dto"
+import (
+	"strconv"
+
+	"github.com/FIAP-SOAT-G20/tc4-customer-service/internal/core/dto"
+)
 
 type CustomerRequest struct {
 	ID    string `json:"id,omitempty"`
@@ -10,8 +14,9 @@ type CustomerRequest struct {
 }
 
 func (c CustomerRequest) ToGetCustomerInput() dto.GetCustomerInput {
+	id, _ := strconv.Atoi(c.ID)
 	return dto.GetCustomerInput{
-		ID: c.ID,
+		ID: id,
 	}
 }
 
@@ -24,8 +29,9 @@ func (c CustomerRequest) ToCreateCustomerInput() dto.CreateCustomerInput {
 }
 
 func (c CustomerRequest) ToUpdateCustomerInput() dto.UpdateCustomerInput {
+	id, _ := strconv.Atoi(c.ID)
 	return dto.UpdateCustomerInput{
-		ID:    c.ID,
+		ID:    id,
 		Name:  c.Name,
 		Email: c.Email,
 	}

--- a/internal/infrastructure/datasource/customer_datasource_dynamo_test.go
+++ b/internal/infrastructure/datasource/customer_datasource_dynamo_test.go
@@ -79,7 +79,7 @@ func (suite *CustomerDynamoDataSourceIntegrationTestSuite) TestDynamoFindByID() 
 
 	tests := []struct {
 		name      string
-		id        string
+		id        int
 		wantFound bool
 	}{
 		{
@@ -89,7 +89,7 @@ func (suite *CustomerDynamoDataSourceIntegrationTestSuite) TestDynamoFindByID() 
 		},
 		{
 			name:      "should return nil for non-existent customer",
-			id:        "non-existent-id",
+			id:        999999,
 			wantFound: false,
 		},
 	}
@@ -284,7 +284,7 @@ func (suite *CustomerDynamoDataSourceIntegrationTestSuite) TestDynamoUpdate() {
 		{
 			name: "should fail to update with non-existent ID",
 			updateData: func(c *entity.Customer) {
-				c.ID = "non-existent-id"
+				c.ID = 999999
 				c.Name = "Should not update"
 			},
 			wantErr: true,
@@ -328,7 +328,7 @@ func (suite *CustomerDynamoDataSourceIntegrationTestSuite) TestDynamoDelete() {
 
 	tests := []struct {
 		name    string
-		id      string
+		id      int
 		wantErr bool
 	}{
 		{
@@ -338,7 +338,7 @@ func (suite *CustomerDynamoDataSourceIntegrationTestSuite) TestDynamoDelete() {
 		},
 		{
 			name:    "should fail to delete non-existent customer",
-			id:      "non-existent-id",
+			id:      999999,
 			wantErr: true,
 		},
 	}

--- a/test/bdd/features/customer_management.feature
+++ b/test/bdd/features/customer_management.feature
@@ -16,15 +16,20 @@ Feature: Customer Management
     And the response should contain customer details
 
   Scenario: Get customer by ID
-    Given a customer exists with ID "507f1f77bcf86cd799439011"
-    When I send a request to get customer with ID "507f1f77bcf86cd799439011"
+    Given a customer exists with ID "123"
+    When I send a request to get customer with ID "123"
     Then I should receive a response with status 200
     And the response should contain customer details
 
   Scenario: Get customer by non-existent ID
-    When I send a request to get customer with ID "507f1f77bcf86cd799439999"
+    When I send a request to get customer with ID "999999"
     Then I should receive a response with status 404
     And the response should contain an error message "Customer not found"
+
+  Scenario: Get customer by invalid ID format
+    When I send a request to get customer with ID "invalid-id"
+    Then I should receive a response with status 400
+    And the response should contain an error message "Invalid customer ID"
 
   Scenario: Get customer by CPF
     Given a customer exists with CPF "12345678901"
@@ -47,25 +52,25 @@ Feature: Customer Management
     And the response should contain a list of 2 customers
 
   Scenario: Update customer information
-    Given a customer exists with ID "507f1f77bcf86cd799439011"
-    When I send a request to update customer with ID "507f1f77bcf86cd799439011" with the following details:
+    Given a customer exists with ID "123"
+    When I send a request to update customer with ID "123" with the following details:
       | name  | John Updated         |
       | email | john_new@example.com |
     Then I should receive a response with status 200
     And the response should contain the updated customer details
 
   Scenario: Update non-existent customer
-    When I send a request to update customer with ID "507f1f77bcf86cd799439999" with the following details:
+    When I send a request to update customer with ID "999999" with the following details:
       | name | John Updated |
     Then I should receive a response with status 404
     And the response should contain an error message "Customer not found"
 
   Scenario: Delete customer
-    Given a customer exists with ID "507f1f77bcf86cd799439011"
-    When I send a request to delete customer with ID "507f1f77bcf86cd799439011"
+    Given a customer exists with ID "123"
+    When I send a request to delete customer with ID "123"
     Then I should receive a response with status 204
 
   Scenario: Delete non-existent customer
-    When I send a request to delete customer with ID "507f1f77bcf86cd799439999"
+    When I send a request to delete customer with ID "999999"
     Then I should receive a response with status 404
     And the response should contain an error message "Customer not found"

--- a/test/data/delete_customer.json
+++ b/test/data/delete_customer.json
@@ -1,6 +1,6 @@
 {
   "resource": "/customers/{id}",
-  "path": "/customers/60f1b2b3c4d5e6f7a8b9c0d1",
+  "path": "/customers/123",
   "httpMethod": "DELETE",
   "headers": {
     "Content-Type": "application/json"
@@ -13,7 +13,7 @@
   "queryStringParameters": null,
   "multiValueQueryStringParameters": null,
   "pathParameters": {
-    "id": "60f1b2b3c4d5e6f7a8b9c0d1"
+    "id": "123"
   },
   "stageVariables": {
     "env": "test"

--- a/test/data/get_customer_by_id.json
+++ b/test/data/get_customer_by_id.json
@@ -1,6 +1,6 @@
 {
   "resource": "/customers/{id}",
-  "path": "/customers/60f1b2b3c4d5e6f7a8b9c0d1",
+  "path": "/customers/123",
   "httpMethod": "GET",
   "headers": {
     "Content-Type": "application/json"
@@ -13,7 +13,7 @@
   "queryStringParameters": null,
   "multiValueQueryStringParameters": null,
   "pathParameters": {
-    "id": "60f1b2b3c4d5e6f7a8b9c0d1"
+    "id": "123"
   },
   "stageVariables": {
     "env": "test"

--- a/test/data/update_customer.json
+++ b/test/data/update_customer.json
@@ -1,6 +1,6 @@
 {
   "resource": "/customers/{id}",
-  "path": "/customers/60f1b2b3c4d5e6f7a8b9c0d1",
+  "path": "/customers/123",
   "httpMethod": "PUT",
   "headers": {
     "Content-Type": "application/json"
@@ -13,7 +13,7 @@
   "queryStringParameters": null,
   "multiValueQueryStringParameters": null,
   "pathParameters": {
-    "id": "60f1b2b3c4d5e6f7a8b9c0d1"
+    "id": "123"
   },
   "stageVariables": {
     "env": "test"


### PR DESCRIPTION
## Description

This pull request refactors the customer ID across the project by converting it from a string type to an integer type. The changes ensure uniformity and simplify customer ID handling.

## Changes

- Updated domain models, DTOs, and entity definitions to use integer type for customer IDs.
- Adjusted methods, interfaces, and controllers to work with integer-based customer IDs.
- Modified test data and test cases to align with the new customer ID type.
- Replaced UUID generation for new customer IDs with an integer ID generation based on timestamps.
- Implemented error handling for invalid ID conversions.

## Additional Information

- Ensure proper testing of all endpoints and methods that involve customer ID operations.
- Test cases have been updated to reflect the changes; coverage should be verified.

## Checklist

- [ ] Tests passed
- [ ] Changes are covered by tests
- [ ] Documentation updated
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)